### PR TITLE
clean code: server controllers/testing/reset to use test_helper for test users & test senders

### DIFF
--- a/server/controllers/testing.js
+++ b/server/controllers/testing.js
@@ -1,73 +1,12 @@
 const router = require('express').Router()
 const User = require('../models/user')
 const Sender = require('../models/sender')
+const helper = require('../test/test_helper')
 const bcrypt = require('bcrypt')
-
-const expiredDate = new Date('2000-04-20T06:12:14.241Z')
-const nonExpiredDate = new Date('3000-04-20T06:12:14.241Z')
-const userUser = () => ({
-  username: 'user@user',
-  firstName: 'UserTest',
-  lastName: 'UserTest',
-  address: 'UserStreet',
-  postalCode: '00100',
-  city: 'Helsinki',
-  role: 'user',
-  expirationDate: nonExpiredDate,
-  senderDeviceIds: ['E00208B4'],
-  password: 'user@user',
-})
-
-const expiredUser = () => ({
-  username: 'expireduser@user',
-  firstName: 'ExpiredUserTest',
-  lastName: 'ExpiredUserTest',
-  address: 'UserStreet',
-  postalCode: '00100',
-  city: 'Helsinki',
-  role: 'user',
-  expirationDate: expiredDate,
-  senderDeviceIds: ['E00208B4'],
-  password: 'expireduser@user',
-})
-
-const adminUser = () => ({
-  username: 'admin@admin',
-  firstName: 'AdminTest',
-  lastName: 'AdminTest',
-  address: 'AdminStreet',
-  postalCode: '00100',
-  city: 'Helsinki',
-  role: 'admin',
-  expirationDate: nonExpiredDate,
-  senderDeviceIds: ['E00208B4'],
-  password: 'admin@admin',
-})
-
-const smallSender = () => ({
-  seq_number:226,
-  device: 'E00208B4',
-  sen_battery: 1.66,
-  date: expiredDate,
-  sen_id: '6a',
-  measurement: 55
-})
-
-const bigSender = () => ({
-  seq_number: 2,
-  device: 'E00208B4',
-  sen_battery: 2.78,
-  date: expiredDate,
-  sen_id: 'f3',
-  dev_battery: 3.19,
-  temperature: 21.04,
-  humidity: 27.41,
-  pressure: 101823
-})
 
 router.post('/reset', async (request, response) => {
   await User.deleteMany({})
-  const testUsers = [userUser(), expiredUser(), adminUser()]
+  const testUsers = [helper.userUser(), helper.expiredUser(), helper.adminUser()]
   const saltRounds = 10
 
   let savedUsers = []
@@ -81,9 +20,9 @@ router.post('/reset', async (request, response) => {
     savedUsers = savedUsers.concat(savedUser)
   }
   await Sender.deleteMany({})
-  const mongoSender = new Sender(smallSender())
+  const mongoSender = new Sender(helper.smallSender())
   await mongoSender.save()
-  const mongoSender2 = new Sender(bigSender())
+  const mongoSender2 = new Sender(helper.bigSender())
   await mongoSender2.save()
   response.status(201).json(savedUsers)
 })

--- a/server/test/login_api.test.js
+++ b/server/test/login_api.test.js
@@ -3,10 +3,8 @@ const supertest = require('supertest')
 const helper = require('./test_helper')
 const app = require('../app')
 const api = supertest(app)
-const User = require('../models/user')
 
 beforeAll(async () => {
-  await User.deleteMany({})
   await supertest(app)
     .post('/api/testing/reset')
     .expect(201)
@@ -101,6 +99,5 @@ describe('When there is initially one admin-user and two user-users at db', () =
       .send(userdata)
       .expect(401)
       .expect('Content-Type', /application\/json/)
-
   })
 })

--- a/server/test/test_helper.js
+++ b/server/test/test_helper.js
@@ -52,6 +52,26 @@ const adminUser = () => ({
   password: 'admin@admin',
 })
 
+const smallSender = () => ({
+  seq_number: 226,
+  device: 'E00208B4',
+  sen_battery: 1.66,
+  date: expiredDate,
+  sen_id: '6a',
+  measurement: 55
+})
+
+const bigSender = () => ({
+  seq_number: 2,
+  device: 'E00208B4',
+  sen_battery: 2.78,
+  date: expiredDate,
+  sen_id: 'f3',
+  dev_battery: 3.19,
+  temperature: 21.04,
+  humidity: 27.41,
+  pressure: 101823
+})
 module.exports = {
-  usersInDb,sendersInDb, userUser, adminUser, expiredUser
+  usersInDb,sendersInDb, userUser, adminUser, expiredUser, smallSender, bigSender
 }

--- a/server/test/user_api.test.js
+++ b/server/test/user_api.test.js
@@ -3,14 +3,12 @@ const supertest = require('supertest')
 const helper = require('./test_helper')
 const app = require('../app')
 const api = supertest(app)
-//const User = require('../models/user')
 
 let ADMINTOKEN = ''
 let USERTOKEN = ''
 let WRONGTOKEN = ''
 
 beforeAll(async () => {
- // await User.deleteMany({})
   await supertest(app)
     .post('/api/testing/reset')
     .expect(201)
@@ -65,7 +63,7 @@ describe('When there is initially one admin - user and two user - users at db', 
       .expect('Content-Type', /application\/json/)
     const usersAtEnd = await helper.usersInDb()
     expect(usersAtEnd).toHaveLength(usersAtStart.length)
-  }) 
+  })
 
   test('USER creation fails if username already exists if ADMIN posts', async () => {
     const usersAtStart = await helper.usersInDb()


### PR DESCRIPTION
Test user creation was duplicated, removed another from server controllers/testing/reset and  replaced  & fixed to use test_helper.js instead for creating test users & test senders. 

Removed some useless comments in server testing files.