### PR TITLE
Datepicker refactor and testing

### DIFF
--- a/client/cypress/e2e/anturi_app.cy.js
+++ b/client/cypress/e2e/anturi_app.cy.js
@@ -73,7 +73,7 @@ describe('Anturi app', function () {
         cy.get('[data-cy="password"]').type('&')
         cy.contains('Salasanan täytyy sisältää').should('not.exist')
       })
-      it('admin can create new user with default date when all fields are filled', function () {
+      it('create new user with default date when all fields are filled', function () {
         cy.get('[data-cy="role"]').select('user')
         cy.get('[data-cy="firstName"]').type(userUser().firstName)
         cy.get('[data-cy="lastName"]').type(userUser().lastName)
@@ -85,7 +85,7 @@ describe('Anturi app', function () {
         cy.get('[data-cy="addUser"]').click()
         cy.contains('Käyttäjän luonti onnistui!')
       })
-      it('admin can not create user if username is taken', function () {
+      it('can not create user if username is taken', function () {
         cy.get('[data-cy="role"]').select('user')
         cy.get('[data-cy="firstName"]').type(userUser().firstName)
         cy.get('[data-cy="lastName"]').type(userUser().lastName)
@@ -96,6 +96,21 @@ describe('Anturi app', function () {
         cy.get('[data-cy="password"]').type(userUser().password)
         cy.get('[data-cy="addUser"]').click()
         cy.contains('Käyttäjä tällä sähköpostilla on jo olemassa!')
+      })
+      it.only('create new user non expired user and try to login with that user', function () {
+        cy.get('[data-cy="expirationDate"]').type('2050-01-01')
+        cy.get('[data-cy="role"]').select('user')
+        cy.get('[data-cy="firstName"]').type(userUser().firstName)
+        cy.get('[data-cy="lastName"]').type(userUser().lastName)
+        cy.get('[data-cy="email"]').type('testi@testi.net')
+        cy.get('[data-cy="adress"]').type(userUser().address)
+        cy.get('[data-cy="postalCode"]').type(userUser().postalCode)
+        cy.get('[data-cy="city"]').type(userUser().city)
+        cy.get('[data-cy="password"]').type(userUser().password)
+        cy.get('[data-cy="addUser"]').click()
+        cy.contains('Käyttäjän luonti onnistui!')
+        cy.login({ username: 'testi@testi.net', password: userUser().password })
+        cy.contains('sisäänkirjautunut')
       })
       it('registeration fails if some field is empty', function () {
         cy.get('[data-cy="addUser"]').click()

--- a/client/src/components/RegisterForm.js
+++ b/client/src/components/RegisterForm.js
@@ -112,11 +112,16 @@ const RegisterForm = ({ setNotification }) => {
         </p>
         <label><h3>Käyttäjätunnus voimassa: </h3></label>
         <input type="date" name="expiration"
-          value={expirationDate.toLocaleDateString('en-CA')}
+          value={expirationDate.toISOString().substring(0, 10)}
           data-cy='expirationDate'
-          min="2023-01-01" max="2050-01-01"
-          onKeyDown={(e) => e.preventDefault()}
-          onChange={(e) => setExpirationDate(new Date(e.target.value))
+          max="2100-01-01"
+          onChange={(e) =>
+            setExpirationDate(
+              e.target.value === ''
+                ? new Date()
+                : new Date(e.target.value) > new Date('2100-01-01')
+                  ? new Date('2100-01-01')
+                  : new Date(e.target.value))
           } />
         <label><h3>Nimi</h3></label>
         <small>Etunimi</small>


### PR DESCRIPTION
#278
Input type=date refactored to allow typing input inorder to test. 
Made 'smarter' onChange handling, because earlier did not simply work.
Removed input restraint on expiredDates dates.