### PR TITLE
User sees his/her first sender visualization

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -107,6 +107,7 @@ function App() {
       >
         Kirjaudu ulos
       </button>
+      <div>{userDetails}</div>
       <Togglable buttonLabel='Näytä laitteet' id='senderList'>
         <SenderList senders={senders} />
       </Togglable>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,7 +34,7 @@ function App() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await senderService.getOneSenderLogs(user.senderDeviceIds, user.token)
+      const data = await senderService.getOneSenderLogs(user.senderDeviceIds[0], user.token)
 
       setSenders(data)
     }
@@ -107,7 +107,7 @@ function App() {
       >
         Kirjaudu ulos
       </button>
-      <div>{userDetails}</div>
+
       <Togglable buttonLabel='Näytä laitteet' id='senderList'>
         <SenderList senders={senders} />
       </Togglable>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -107,7 +107,7 @@ function App() {
       >
         Kirjaudu ulos
       </button>
-
+      <div>{userDetails}</div>
       <Togglable buttonLabel='Näytä laitteet' id='senderList'>
         <SenderList senders={senders} />
       </Togglable>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,12 +34,12 @@ function App() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data = await senderService.getAll(user.token)
+      const data = await senderService.getOneSenderLogs(user.senderDeviceIds, user.token)
 
       setSenders(data)
     }
     if (user) {
-      if (user.role === 'admin') {
+      if (user.role === 'user') {
         fetchData()
       }
     }
@@ -89,9 +89,6 @@ function App() {
         <Togglable buttonLabel='Lisää käyttäjä' id='registerForm'>
           <RegisterForm notificationSetter={notificationSetter} />
         </Togglable>
-        <Togglable buttonLabel='Näytä laitteet' id='senderList'>
-          <SenderList senders={senders} />
-        </Togglable>
       </div>
     )
   }
@@ -110,7 +107,9 @@ function App() {
       >
         Kirjaudu ulos
       </button>
-      <div>{userDetails}</div>
+      <Togglable buttonLabel='Näytä laitteet' id='senderList'>
+        <SenderList senders={senders} />
+      </Togglable>
     </div>
   )
 }

--- a/client/src/services/senderService.js
+++ b/client/src/services/senderService.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 const baseUrl = '/api/senders'
 
 const getAll = async (token) => {
+  console.log(token)
   const config = { headers: { Authorization: `bearer ${token}` }, }
   const response = await axios.get(baseUrl, config)
   return response.data


### PR DESCRIPTION
User front broken because of no rendering of {userDetails}. Works when removed. 
This feature is added by Riikka next, pushed to main for her to implement on top.

