### PR TITLE
bring back tooltip label format

### DIFF
--- a/client/src/components/SensorChart.js
+++ b/client/src/components/SensorChart.js
@@ -190,6 +190,7 @@ const SensorChart = ({ parameter, ids, logs }) => {
           <Tooltip
             labelStyle={fontStyle}
             contentStyle={fontStyle}
+            labelFormatter={(value) => format(value, "dd/MM/yyyy 'klo' HH:mm")}
           />
           <Legend
             wrapperStyle={fontStyle}


### PR DESCRIPTION
Poistin vahingossa Johanneksen tooltip labelin kun tein omia, tää tuo sen takas